### PR TITLE
Add native transport support

### DIFF
--- a/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/DriftNettyConnectionFactoryConfig.java
+++ b/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/DriftNettyConnectionFactoryConfig.java
@@ -16,6 +16,7 @@
 package com.facebook.drift.transport.netty.client;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
 import com.google.common.net.HostAndPort;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
@@ -36,6 +37,7 @@ public class DriftNettyConnectionFactoryConfig
 
     private Duration sslContextRefreshTime = new Duration(1, MINUTES);
     private HostAndPort socksProxy;
+    private boolean nativeTransportEnabled;
 
     public int getThreadCount()
     {
@@ -109,6 +111,19 @@ public class DriftNettyConnectionFactoryConfig
     public DriftNettyConnectionFactoryConfig setSocksProxy(HostAndPort socksProxy)
     {
         this.socksProxy = socksProxy;
+        return this;
+    }
+
+    public boolean isNativeTransportEnabled()
+    {
+        return nativeTransportEnabled;
+    }
+
+    @Config("thrift.client.native-transport.enabled")
+    @ConfigDescription("Enable Native Transport")
+    public DriftNettyConnectionFactoryConfig setNativeTransportEnabled(boolean nativeTransportEnabled)
+    {
+        this.nativeTransportEnabled = nativeTransportEnabled;
         return this;
     }
 }

--- a/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/server/DriftNettyServerConfig.java
+++ b/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/server/DriftNettyServerConfig.java
@@ -16,6 +16,7 @@
 package com.facebook.drift.transport.netty.server;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
@@ -57,6 +58,7 @@ public class DriftNettyServerConfig
     private Duration sessionTimeout = new Duration(1, DAYS);
 
     private boolean assumeClientsSupportOutOfOrderResponses = true;
+    private boolean nativeTransportEnabled;
 
     @Min(0)
     @Max(65535)
@@ -271,6 +273,19 @@ public class DriftNettyServerConfig
     public DriftNettyServerConfig setAssumeClientsSupportOutOfOrderResponses(boolean assumeClientsSupportOutOfOrderResponses)
     {
         this.assumeClientsSupportOutOfOrderResponses = assumeClientsSupportOutOfOrderResponses;
+        return this;
+    }
+
+    public boolean isNativeTransportEnabled()
+    {
+        return nativeTransportEnabled;
+    }
+
+    @Config("thrift.server.native-transport.enabled")
+    @ConfigDescription("Enable Native Transport")
+    public DriftNettyServerConfig setNativeTransportEnabled(boolean nativeTransportEnabled)
+    {
+        this.nativeTransportEnabled = nativeTransportEnabled;
         return this;
     }
 }

--- a/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestDriftNettyConnectionFactoryConfig.java
+++ b/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestDriftNettyConnectionFactoryConfig.java
@@ -38,7 +38,8 @@ public class TestDriftNettyConnectionFactoryConfig
                 .setConnectionPoolMaxSize(1000)
                 .setConnectionPoolIdleTimeout(new Duration(1, MINUTES))
                 .setSslContextRefreshTime(new Duration(1, MINUTES))
-                .setSocksProxy(null));
+                .setSocksProxy(null)
+                .setNativeTransportEnabled(false));
     }
 
     @Test
@@ -51,6 +52,7 @@ public class TestDriftNettyConnectionFactoryConfig
                 .put("thrift.client.connection-pool.idle-timeout", "7m")
                 .put("thrift.client.ssl-context.refresh-time", "33m")
                 .put("thrift.client.socks-proxy", "example.com:9876")
+                .put("thrift.client.native-transport.enabled", "true")
                 .build();
 
         DriftNettyConnectionFactoryConfig expected = new DriftNettyConnectionFactoryConfig()
@@ -59,7 +61,8 @@ public class TestDriftNettyConnectionFactoryConfig
                 .setConnectionPoolMaxSize(555)
                 .setConnectionPoolIdleTimeout(new Duration(7, MINUTES))
                 .setSslContextRefreshTime(new Duration(33, MINUTES))
-                .setSocksProxy(HostAndPort.fromParts("example.com", 9876));
+                .setSocksProxy(HostAndPort.fromParts("example.com", 9876))
+                .setNativeTransportEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/server/TestDriftNettyServerConfig.java
+++ b/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/server/TestDriftNettyServerConfig.java
@@ -52,7 +52,8 @@ public class TestDriftNettyServerConfig
                 .setSessionCacheSize(10_000)
                 .setSessionTimeout(new Duration(1, DAYS))
                 .setCiphers("")
-                .setAssumeClientsSupportOutOfOrderResponses(true));
+                .setAssumeClientsSupportOutOfOrderResponses(true)
+                .setNativeTransportEnabled(false));
     }
 
     @Test
@@ -75,6 +76,7 @@ public class TestDriftNettyServerConfig
                 .put("thrift.server.ssl.session-timeout", "78h")
                 .put("thrift.server.ssl.ciphers", "some_cipher")
                 .put("thrift.server.assume-clients-support-out-of-order-responses", "false")
+                .put("thrift.server.native-transport.enabled", "true")
                 .build();
 
         DriftNettyServerConfig expected = new DriftNettyServerConfig()
@@ -93,7 +95,8 @@ public class TestDriftNettyServerConfig
                 .setSessionCacheSize(678)
                 .setSessionTimeout(new Duration(78, HOURS))
                 .setCiphers("some_cipher")
-                .setAssumeClientsSupportOutOfOrderResponses(false);
+                .setAssumeClientsSupportOutOfOrderResponses(false)
+                .setNativeTransportEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,13 @@
             </dependency>
 
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>4.1.29.Final</version>
+                <classifier>linux-x86_64</classifier>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.6</version>


### PR DESCRIPTION
Adding native transport support for Linux systems.
We check to see if Epoll support is available and try to use that
instead of NIO. The benefits include generating less garbage and
improving performance.

Turning on Native Transport for all Netty IO

|Percentile|Epoll vs NIO Improvement in Wall Time |
|--------|---------------------------------------|
|avg|4.24%|
| p50|1.61%|
|p75|-0.54%|
|p95|3.01%|
|p99|7.24%|

|Percentile|Epoll vs NIO Improvement in CPU Time |
|--------|---------------------------------------|
|avg|1.79%|
| p50|0.28%|
|p75|1.60%|
|p95|0.58%|
|p99|2.55%|

I'm able to see a good improvement in Wall time in p95 and p99 percentiles and some moderate CPU efficiency wins. I think it might be worth using Native Transport.



