### PR TITLE
Add support to read data directly into output buffer

### DIFF
--- a/drift-codec/src/main/java/com/facebook/drift/codec/internal/ProtocolReader.java
+++ b/drift-codec/src/main/java/com/facebook/drift/codec/internal/ProtocolReader.java
@@ -127,6 +127,18 @@ public class ProtocolReader
         return fieldValue;
     }
 
+    public int readBinaryField(byte[] buf, int offset)
+            throws TException
+    {
+        if (!checkReadState(TType.STRING)) {
+            return 0;
+        }
+        currentField = null;
+        int length = protocol.readBinary(buf, offset);
+        protocol.readFieldEnd();
+        return length;
+    }
+
     public boolean readBoolField()
             throws TException
     {

--- a/drift-protocol/pom.xml
+++ b/drift-protocol/pom.xml
@@ -22,6 +22,11 @@
             <artifactId>drift-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/drift-protocol/src/main/java/com/facebook/drift/protocol/TBinaryProtocol.java
+++ b/drift-protocol/src/main/java/com/facebook/drift/protocol/TBinaryProtocol.java
@@ -19,10 +19,13 @@ import com.facebook.drift.TException;
 
 import java.nio.ByteBuffer;
 
+import static com.facebook.drift.protocol.TProtocolUtil.readAllInBatches;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Double.longBitsToDouble;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.intBitsToFloat;
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
@@ -389,6 +392,16 @@ public class TBinaryProtocol
         byte[] buf = new byte[size];
         transport.read(buf, 0, size);
         return ByteBuffer.wrap(buf);
+    }
+
+    @Override
+    public int readBinary(byte[] buf, int offset)
+            throws TException
+    {
+        int size = checkSize(readI32());
+        checkArgument((buf.length - offset) >= size, format("Binary is too large to be read into buffer: binary size: %s, buffer size: %s, buffer offset: %s", size, buf.length, offset));
+
+        return readAllInBatches(transport, buf, offset, size);
     }
 
     private static int checkSize(int length)

--- a/drift-protocol/src/main/java/com/facebook/drift/protocol/TCompactProtocol.java
+++ b/drift-protocol/src/main/java/com/facebook/drift/protocol/TCompactProtocol.java
@@ -21,10 +21,13 @@ import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
+import static com.facebook.drift.protocol.TProtocolUtil.readAllInBatches;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Double.longBitsToDouble;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.intBitsToFloat;
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
@@ -772,6 +775,19 @@ public class TCompactProtocol
         byte[] buf = new byte[length];
         transport.read(buf, 0, length);
         return ByteBuffer.wrap(buf);
+    }
+
+    /**
+     * Read data from wire directly into the buffer
+     */
+    @Override
+    public int readBinary(byte[] buf, int offset)
+            throws TException
+    {
+        int size = checkSize(readVarint32());
+        checkArgument((buf.length - offset) >= size, format("Binary is too large to be read into buffer: binary size: %s, buffer size: %s, buffer offset: %s", size, buf.length, offset));
+
+        return readAllInBatches(transport, buf, offset, size);
     }
 
     /**

--- a/drift-protocol/src/main/java/com/facebook/drift/protocol/TFacebookCompactProtocol.java
+++ b/drift-protocol/src/main/java/com/facebook/drift/protocol/TFacebookCompactProtocol.java
@@ -21,10 +21,13 @@ import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
+import static com.facebook.drift.protocol.TProtocolUtil.readAllInBatches;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Double.longBitsToDouble;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.intBitsToFloat;
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
@@ -772,6 +775,19 @@ public class TFacebookCompactProtocol
         byte[] buf = new byte[length];
         transport.read(buf, 0, length);
         return ByteBuffer.wrap(buf);
+    }
+
+    /**
+     * Read data from wire directly into the buffer.
+     */
+    @Override
+    public int readBinary(byte[] buf, int offset)
+            throws TException
+    {
+        int size = checkSize(readVarint32());
+        checkArgument((buf.length - offset) >= size, format("Binary is too large to be read into buffer: binary size: %s, buffer size: %s, buffer offset: %s", size, buf.length, offset));
+
+        return readAllInBatches(transport, buf, offset, size);
     }
 
     /**

--- a/drift-protocol/src/main/java/com/facebook/drift/protocol/TProtocolReader.java
+++ b/drift-protocol/src/main/java/com/facebook/drift/protocol/TProtocolReader.java
@@ -83,4 +83,7 @@ public interface TProtocolReader
 
     ByteBuffer readBinary()
             throws TException;
+
+    int readBinary(byte[] buf, int offset)
+            throws TException;
 }

--- a/drift-protocol/src/main/java/com/facebook/drift/protocol/TProtocolUtil.java
+++ b/drift-protocol/src/main/java/com/facebook/drift/protocol/TProtocolUtil.java
@@ -94,4 +94,17 @@ public final class TProtocolUtil
                 throw new TProtocolException("Unknown type: " + type);
         }
     }
+
+    public static int readAllInBatches(TTransport transport, byte[] buf, int offset, int size)
+            throws TException
+    {
+        while (size > 0) {
+            // read data in 64KB chunks to optimize buffer allocation inside the JVM
+            int readSize = Math.min(size, 65536);
+            transport.read(buf, offset, readSize);
+            size -= readSize;
+            offset += readSize;
+        }
+        return size;
+    }
 }

--- a/drift-transport-apache/src/main/java/com/facebook/drift/transport/apache/client/ThriftToDriftProtocolReader.java
+++ b/drift-transport-apache/src/main/java/com/facebook/drift/transport/apache/client/ThriftToDriftProtocolReader.java
@@ -291,4 +291,10 @@ public class ThriftToDriftProtocolReader
             throw new TException(e);
         }
     }
+
+    @Override
+    public int readBinary(byte[] buf, int offset)
+    {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
This PR has code changes to read data directly into buffer provided by the Presto. This is to avoid the double copy (wire to Thrift object, Thrift object to Presto buffer)