### PR TITLE
DRAFT. Fix Issue 15. Test failure which blocks Netty version upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,13 +183,13 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-                <version>4.1.29.Final</version>
+                <version>4.1.37.Final</version>
             </dependency>
 
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-epoll</artifactId>
-                <version>4.1.29.Final</version>
+                <version>4.1.37.Final</version>
                 <classifier>linux-x86_64</classifier>
             </dependency>
 


### PR DESCRIPTION
### Summary
Currently, cannot upgrade to a newer version of Netty because one of the unit tests breaks after detecting a bug in the newer version of Netty.

This is because in version 4.1.38.Final of Netty (https://bintray.com/netty/downloads/netty/ ) a bug was introduced so that Second request future changed from [null] to an object in a PENDING state.

I've filed https://github.com/netty/netty/issues/10433 for that project.

Also, I've upgraded to the highest possible version of Netty that does work and changed the unit test to JUnit.

### Tests
Verified compilation, packaging, and unit tests.
```
# Individual test
$ cd drift-transport-netty
$ mvn clean test -Dtest=TestDriftNettyServerTransport

# All
$ cd ..
$ mvn clean install
$ mvn clean test
```
<img width="1278" alt="netty_mvn_clean_install" src="https://user-images.githubusercontent.com/225711/88583794-974c5f00-d005-11ea-8c20-39da55880c74.png">

<img width="1279" alt="netty_mvn_clean_test" src="https://user-images.githubusercontent.com/225711/88583829-a206f400-d005-11ea-8965-3247d3c447e5.png">


