### PR TITLE
Add URI Thrift codec

### DIFF
--- a/drift-codec/src/main/java/com/facebook/drift/codec/ThriftCodecManager.java
+++ b/drift-codec/src/main/java/com/facebook/drift/codec/ThriftCodecManager.java
@@ -37,6 +37,7 @@ import com.facebook.drift.codec.internal.builtin.SetThriftCodec;
 import com.facebook.drift.codec.internal.builtin.ShortArrayThriftCodec;
 import com.facebook.drift.codec.internal.builtin.ShortThriftCodec;
 import com.facebook.drift.codec.internal.builtin.StringThriftCodec;
+import com.facebook.drift.codec.internal.builtin.UriThriftCodec;
 import com.facebook.drift.codec.internal.builtin.VoidThriftCodec;
 import com.facebook.drift.codec.internal.coercion.CoercionThriftCodec;
 import com.facebook.drift.codec.internal.compiler.CompilerThriftCodecFactory;
@@ -174,6 +175,7 @@ public final class ThriftCodecManager
         addBuiltinCodec(new ByteBufferThriftCodec());
         addBuiltinCodec(new StringThriftCodec());
         addBuiltinCodec(new VoidThriftCodec());
+        addBuiltinCodec(new UriThriftCodec(catalog));
         addBuiltinCodec(new BooleanArrayThriftCodec());
         addBuiltinCodec(new ShortArrayThriftCodec());
         addBuiltinCodec(new IntArrayThriftCodec());

--- a/drift-codec/src/main/java/com/facebook/drift/codec/internal/builtin/UriThriftCodec.java
+++ b/drift-codec/src/main/java/com/facebook/drift/codec/internal/builtin/UriThriftCodec.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.drift.codec.internal.builtin;
+
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.internal.coercion.FromThrift;
+import com.facebook.drift.codec.internal.coercion.ToThrift;
+import com.facebook.drift.codec.metadata.ThriftCatalog;
+import com.facebook.drift.codec.metadata.ThriftType;
+import com.facebook.drift.protocol.TProtocolReader;
+import com.facebook.drift.protocol.TProtocolWriter;
+
+import java.net.URI;
+
+import static java.util.Objects.requireNonNull;
+
+public class UriThriftCodec
+        implements ThriftCodec<URI>
+{
+    public UriThriftCodec(ThriftCatalog thriftCatalog)
+    {
+        requireNonNull(thriftCatalog, "thriftCatalog is null");
+        thriftCatalog.addDefaultCoercions(getClass());
+    }
+
+    @Override
+    public ThriftType getType()
+    {
+        return new ThriftType(ThriftType.STRING, URI.class);
+    }
+
+    @Override
+    public URI read(TProtocolReader protocol)
+            throws Exception
+    {
+        requireNonNull(protocol, "protocol is null");
+        return URI.create(protocol.readString());
+    }
+
+    @Override
+    public void write(URI value, TProtocolWriter protocol)
+            throws Exception
+    {
+        requireNonNull(value, "value is null");
+        requireNonNull(protocol, "protocol is null");
+        protocol.writeString(value.toString());
+    }
+
+    @FromThrift
+    public static URI stringToUri(String uri)
+    {
+        return URI.create(uri);
+    }
+
+    @ToThrift
+    public static String uriToString(URI uri)
+    {
+        return uri.toString();
+    }
+}

--- a/drift-codec/src/test/java/com/facebook/drift/codec/AbstractThriftCodecManagerTest.java
+++ b/drift-codec/src/test/java/com/facebook/drift/codec/AbstractThriftCodecManagerTest.java
@@ -55,6 +55,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Type;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -290,6 +291,38 @@ public abstract class AbstractThriftCodecManagerTest
                 ImmutableMap.of((short) 1, new double[] {40, 41, 42, 43}, (short) 2, new double[] {45, 46, 47, 48}));
 
         testRoundTripSerialize(arrayField, TCompactProtocol::new);
+    }
+
+    @Test
+    public void testUri()
+            throws Exception
+    {
+        UriField uriField = new UriField(URI.create("http://fake.uri"));
+        testRoundTripSerialize(uriField);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testUriInvalid()
+            throws Exception
+    {
+        UriField uriField = new UriField(URI.create(">fake"));
+        testRoundTripSerialize(uriField);
+    }
+
+    @Test
+    public void testUriFile()
+            throws Exception
+    {
+        UriField uriField = new UriField(URI.create("file://host/path"));
+        testRoundTripSerialize(uriField);
+    }
+
+    @Test
+    public void testUriMailTo()
+            throws Exception
+    {
+        UriField uriField = new UriField(URI.create("mailto:someone@example.com"));
+        testRoundTripSerialize(uriField);
     }
 
     @Test

--- a/drift-codec/src/test/java/com/facebook/drift/codec/UriField.java
+++ b/drift-codec/src/test/java/com/facebook/drift/codec/UriField.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.drift.codec;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+
+import java.net.URI;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+@ThriftStruct
+public final class UriField
+{
+    @ThriftField(1)
+    public URI uri;
+
+    @ThriftConstructor
+    public UriField(URI uri)
+    {
+        this.uri = uri;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UriField uriField = (UriField) o;
+        return Objects.equals(uri, uriField.uri);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(uri);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("uri", uri)
+                .toString();
+    }
+}


### PR DESCRIPTION
Add URI Thrift codec
Similar to Jackson providing first class support for
certain JDK classes, adding support for a common class java.net.URI
which is used for serde.