### PR TITLE
Add property identifiers for plugin parameters

### DIFF
--- a/drift-maven-plugin/src/main/java/com/facebook/drift/maven/IdlGeneratorMojo.java
+++ b/drift-maven-plugin/src/main/java/com/facebook/drift/maven/IdlGeneratorMojo.java
@@ -55,7 +55,7 @@ public class IdlGeneratorMojo
     /**
      * Drift classes to process.
      */
-    @Parameter(required = true)
+    @Parameter(property = "generate.thrift.idl.classes", required = true)
     private List<String> classes;
 
     /**
@@ -67,7 +67,7 @@ public class IdlGeneratorMojo
     /**
      * Output file for the generated Thrift IDL.
      */
-    @Parameter(required = true)
+    @Parameter(property = "generate.thrift.idl.outputFile", required = true)
     private File outputFile;
 
     /**
@@ -90,7 +90,7 @@ public class IdlGeneratorMojo
      * If this option is false, any dependent types not specified as class
      * names will need to be specified in the includes mapping.
      */
-    @Parameter(required = true)
+    @Parameter(property = "generate.thrift.idl.recursive", required = true)
     private boolean recursive;
 
     /**


### PR DESCRIPTION
This commit will add property identifiers for the drift idl
maven plugin parameters. Without adding these identifiers the
plugin fails to recognize the -D option for passing in parameters
from command line.


Test plan :

```
mvn com.facebook.drift:drift-maven-plugin:1.29-SNAPSHOT:generate-thrift-idl  -Dclasses="com.facebook.presto.execution.TaskStatus" -Drecursive=true -DoutputFile=out.txt -X

[DEBUG] Configuring mojo com.facebook.drift:drift-maven-plugin:1.29-SNAPSHOT:generate-thrift-idl from plugin realm ClassRealm[plugin>com.facebook.drift:drift-maven-plugin:1.29-SNAPSHOT, parent: sun.misc.Launcher$AppClassLoader@55f96302]
[DEBUG] Configuring mojo 'com.facebook.drift:drift-maven-plugin:1.29-SNAPSHOT:generate-thrift-idl' with basic configurator -->
[DEBUG]   (f) classes = [com.facebook.presto.execution.TaskStatus]
[DEBUG]   (f) classesDirectory = /Users/ajaygeorge/code/presto/presto-main/target/classes
[DEBUG]   (f) outputFile = /Users/ajaygeorge/code/presto/presto-main/out.txt
[DEBUG]   (f) project = MavenProject: com.facebook.presto:presto-main:0.242-SNAPSHOT @ /Users/ajaygeorge/code/presto/presto-main/pom.xml
[DEBUG]   (f) recursive = true
[DEBUG] -- end configuration --
[INFO] Found Thrift type: TaskStatus
[INFO] Wrote Thrift IDL to /Users/ajaygeorge/code/presto/presto-main/out.txt
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```