### PR TITLE
Make connection pool configurable per Drift client

### DIFF
--- a/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/ConnectionFactory.java
+++ b/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/ConnectionFactory.java
@@ -36,6 +36,8 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.primitives.Ints.saturatedCast;
 import static io.netty.channel.ChannelOption.ALLOCATOR;
 import static io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS;
+import static io.netty.channel.ChannelOption.SO_REUSEADDR;
+import static io.netty.channel.ChannelOption.TCP_NODELAY;
 import static java.util.Objects.requireNonNull;
 
 class ConnectionFactory
@@ -73,6 +75,8 @@ class ConnectionFactory
                     .channel(socketChannelClass)
                     .option(ALLOCATOR, allocator)
                     .option(CONNECT_TIMEOUT_MILLIS, saturatedCast(connectionParameters.getConnectTimeout().toMillis()))
+                    .option(TCP_NODELAY, connectionParameters.isTcpNoDelayEnabled())
+                    .option(SO_REUSEADDR, connectionParameters.isReuseAddressEnabled())
                     .handler(new ThriftClientInitializer(
                             connectionParameters.getTransport(),
                             connectionParameters.getProtocol(),

--- a/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/ConnectionManager.java
+++ b/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/ConnectionManager.java
@@ -52,6 +52,9 @@ interface ConnectionManager
         private final Optional<HostAndPort> socksProxy;
         private final Optional<SslContextParameters> sslContextParameters;
 
+        private final boolean tcpNoDelayEnabled;
+        private final boolean reuseAddressEnabled;
+
         public ConnectionParameters(
                 Transport transport,
                 Protocol protocol,
@@ -59,7 +62,9 @@ interface ConnectionManager
                 Duration connectTimeout,
                 Duration requestTimeout,
                 Optional<HostAndPort> socksProxy,
-                Optional<SslContextParameters> sslContextParameters)
+                Optional<SslContextParameters> sslContextParameters,
+                boolean tcpNoDelayEnabled,
+                boolean reuseAddressEnabled)
         {
             this.transport = requireNonNull(transport, "transport is null");
             this.protocol = requireNonNull(protocol, "protocol is null");
@@ -68,6 +73,8 @@ interface ConnectionManager
             this.requestTimeout = requireNonNull(requestTimeout, "requestTimeout is null");
             this.socksProxy = requireNonNull(socksProxy, "socksProxy is null");
             this.sslContextParameters = requireNonNull(sslContextParameters, "sslContextParameters is null");
+            this.tcpNoDelayEnabled = tcpNoDelayEnabled;
+            this.reuseAddressEnabled = reuseAddressEnabled;
         }
 
         public Transport getTransport()
@@ -105,6 +112,16 @@ interface ConnectionManager
             return sslContextParameters;
         }
 
+        public boolean isTcpNoDelayEnabled()
+        {
+            return tcpNoDelayEnabled;
+        }
+
+        public boolean isReuseAddressEnabled()
+        {
+            return reuseAddressEnabled;
+        }
+
         @Override
         public boolean equals(Object o)
         {
@@ -121,13 +138,24 @@ interface ConnectionManager
                     Objects.equals(connectTimeout, that.connectTimeout) &&
                     Objects.equals(requestTimeout, that.requestTimeout) &&
                     Objects.equals(socksProxy, that.socksProxy) &&
-                    Objects.equals(sslContextParameters, that.sslContextParameters);
+                    Objects.equals(sslContextParameters, that.sslContextParameters) &&
+                    tcpNoDelayEnabled == that.tcpNoDelayEnabled &&
+                    reuseAddressEnabled == that.reuseAddressEnabled;
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(transport, protocol, maxFrameSize, connectTimeout, requestTimeout, socksProxy, sslContextParameters);
+            return Objects.hash(
+                    transport,
+                    protocol,
+                    maxFrameSize,
+                    connectTimeout,
+                    requestTimeout,
+                    socksProxy,
+                    sslContextParameters,
+                    tcpNoDelayEnabled,
+                    reuseAddressEnabled);
         }
     }
 }

--- a/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/DriftNettyClientConfig.java
+++ b/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/DriftNettyClientConfig.java
@@ -26,6 +26,7 @@ import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDuration;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import java.io.File;
@@ -58,6 +59,11 @@ public class DriftNettyClientConfig
     private String keyPassword;
     private long sessionCacheSize = 10_000;
     private Duration sessionTimeout = new Duration(1, DAYS);
+
+    private Boolean connectionPoolEnabled;
+    private Integer connectionPoolMaxSize;
+    private Integer connectionPoolMaxConnectionsPerDestination;
+    private Duration connectionPoolIdleTimeout;
 
     @NotNull
     public Transport getTransport()
@@ -223,6 +229,57 @@ public class DriftNettyClientConfig
                 .trimResults()
                 .omitEmptyStrings()
                 .splitToList(requireNonNull(ciphers, "ciphers is null"));
+        return this;
+    }
+
+    public Boolean getConnectionPoolEnabled()
+    {
+        return connectionPoolEnabled;
+    }
+
+    @Config("thrift.client.connection-pool.enabled")
+    public DriftNettyClientConfig setConnectionPoolEnabled(Boolean connectionPoolEnabled)
+    {
+        this.connectionPoolEnabled = connectionPoolEnabled;
+        return this;
+    }
+
+    @Min(1)
+    public Integer getConnectionPoolMaxConnectionsPerDestination()
+    {
+        return connectionPoolMaxConnectionsPerDestination;
+    }
+
+    @Config("thrift.client.connection-pool.max-connections-per-destination")
+    public DriftNettyClientConfig setConnectionPoolMaxConnectionsPerDestination(Integer maxConnectionsPerDestination)
+    {
+        this.connectionPoolMaxConnectionsPerDestination = maxConnectionsPerDestination;
+        return this;
+    }
+
+    @Min(1)
+    public Integer getConnectionPoolMaxSize()
+    {
+        return connectionPoolMaxSize;
+    }
+
+    @Config("thrift.client.connection-pool.max-size")
+    public DriftNettyClientConfig setConnectionPoolMaxSize(Integer connectionPoolMaxSize)
+    {
+        this.connectionPoolMaxSize = connectionPoolMaxSize;
+        return this;
+    }
+
+    @MinDuration("1s")
+    public Duration getConnectionPoolIdleTimeout()
+    {
+        return connectionPoolIdleTimeout;
+    }
+
+    @Config("thrift.client.connection-pool.idle-timeout")
+    public DriftNettyClientConfig setConnectionPoolIdleTimeout(Duration connectionPoolIdleTimeout)
+    {
+        this.connectionPoolIdleTimeout = connectionPoolIdleTimeout;
         return this;
     }
 }

--- a/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/DriftNettyClientConfig.java
+++ b/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/DriftNettyClientConfig.java
@@ -65,6 +65,9 @@ public class DriftNettyClientConfig
     private Integer connectionPoolMaxConnectionsPerDestination;
     private Duration connectionPoolIdleTimeout;
 
+    private boolean tcpNoDelayEnabled;
+    private boolean reuseAddressEnabled;
+
     @NotNull
     public Transport getTransport()
     {
@@ -280,6 +283,30 @@ public class DriftNettyClientConfig
     public DriftNettyClientConfig setConnectionPoolIdleTimeout(Duration connectionPoolIdleTimeout)
     {
         this.connectionPoolIdleTimeout = connectionPoolIdleTimeout;
+        return this;
+    }
+
+    public boolean isTcpNoDelayEnabled()
+    {
+        return tcpNoDelayEnabled;
+    }
+
+    @Config("thrift.client.tcp-no-delay.enabled")
+    public DriftNettyClientConfig setTcpNoDelayEnabled(boolean tcpNoDelayEnabled)
+    {
+        this.tcpNoDelayEnabled = tcpNoDelayEnabled;
+        return this;
+    }
+
+    public boolean isReuseAddressEnabled()
+    {
+        return reuseAddressEnabled;
+    }
+
+    @Config("thrift.client.reuse-address.enabled")
+    public DriftNettyClientConfig setReuseAddressEnabled(boolean reuseAddressEnabled)
+    {
+        this.reuseAddressEnabled = reuseAddressEnabled;
         return this;
     }
 }

--- a/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/DriftNettyMethodInvokerFactory.java
+++ b/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/DriftNettyMethodInvokerFactory.java
@@ -184,6 +184,8 @@ public class DriftNettyMethodInvokerFactory<I>
                 clientConfig.getConnectTimeout(),
                 clientConfig.getRequestTimeout(),
                 socksProxy,
-                sslContextConfig);
+                sslContextConfig,
+                clientConfig.isTcpNoDelayEnabled(),
+                clientConfig.isReuseAddressEnabled());
     }
 }

--- a/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/InvocationResponseFuture.java
+++ b/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/InvocationResponseFuture.java
@@ -72,7 +72,9 @@ class InvocationResponseFuture
                     connectionParameters.getConnectTimeout(),
                     connectionParameters.getRequestTimeout(),
                     connectionParameters.getSocksProxy(),
-                    Optional.empty());
+                    Optional.empty(),
+                    connectionParameters.isTcpNoDelayEnabled(),
+                    connectionParameters.isReuseAddressEnabled());
         }
 
         InvocationResponseFuture future = new InvocationResponseFuture(request, connectionParameters, connectionManager);

--- a/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestConnectionPool.java
+++ b/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestConnectionPool.java
@@ -44,7 +44,7 @@ import static org.testng.Assert.assertTrue;
 
 public class TestConnectionPool
 {
-    private static final ConnectionParameters PARAMETERS = new ConnectionParameters(HEADER, FB_COMPACT, new DataSize(1, MEGABYTE), new Duration(1, MINUTES), new Duration(1, MINUTES), Optional.empty(), Optional.empty());
+    private static final ConnectionParameters PARAMETERS = new ConnectionParameters(HEADER, FB_COMPACT, new DataSize(1, MEGABYTE), new Duration(1, MINUTES), new Duration(1, MINUTES), Optional.empty(), Optional.empty(), false, false);
 
     private ScheduledExecutorService scheduledExecutorService;
 

--- a/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestDriftNettyClientConfig.java
+++ b/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestDriftNettyClientConfig.java
@@ -56,7 +56,11 @@ public class TestDriftNettyClientConfig
                 .setKeyPassword(null)
                 .setSessionCacheSize(10_000)
                 .setSessionTimeout(new Duration(1, DAYS))
-                .setCiphers(""));
+                .setCiphers("")
+                .setConnectionPoolEnabled(null)
+                .setConnectionPoolMaxConnectionsPerDestination(null)
+                .setConnectionPoolMaxSize(null)
+                .setConnectionPoolIdleTimeout(null));
     }
 
     @Test
@@ -76,6 +80,10 @@ public class TestDriftNettyClientConfig
                 .put("thrift.client.ssl.session-cache-size", "678")
                 .put("thrift.client.ssl.session-timeout", "78h")
                 .put("thrift.client.ssl.ciphers", "some_cipher")
+                .put("thrift.client.connection-pool.enabled", "true")
+                .put("thrift.client.connection-pool.max-connections-per-destination", "123")
+                .put("thrift.client.connection-pool.max-size", "321")
+                .put("thrift.client.connection-pool.idle-timeout", "12m")
                 .build();
 
         DriftNettyClientConfig expected = new DriftNettyClientConfig()
@@ -91,7 +99,11 @@ public class TestDriftNettyClientConfig
                 .setKeyPassword("key_password")
                 .setSessionCacheSize(678)
                 .setSessionTimeout(new Duration(78, HOURS))
-                .setCiphers("some_cipher");
+                .setCiphers("some_cipher")
+                .setConnectionPoolEnabled(true)
+                .setConnectionPoolMaxConnectionsPerDestination(123)
+                .setConnectionPoolMaxSize(321)
+                .setConnectionPoolIdleTimeout(new Duration(12, MINUTES));
 
         assertFullMapping(properties, expected);
     }

--- a/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestDriftNettyClientConfig.java
+++ b/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestDriftNettyClientConfig.java
@@ -60,7 +60,9 @@ public class TestDriftNettyClientConfig
                 .setConnectionPoolEnabled(null)
                 .setConnectionPoolMaxConnectionsPerDestination(null)
                 .setConnectionPoolMaxSize(null)
-                .setConnectionPoolIdleTimeout(null));
+                .setConnectionPoolIdleTimeout(null)
+                .setTcpNoDelayEnabled(false)
+                .setReuseAddressEnabled(false));
     }
 
     @Test
@@ -84,6 +86,8 @@ public class TestDriftNettyClientConfig
                 .put("thrift.client.connection-pool.max-connections-per-destination", "123")
                 .put("thrift.client.connection-pool.max-size", "321")
                 .put("thrift.client.connection-pool.idle-timeout", "12m")
+                .put("thrift.client.tcp-no-delay.enabled", "true")
+                .put("thrift.client.reuse-address.enabled", "true")
                 .build();
 
         DriftNettyClientConfig expected = new DriftNettyClientConfig()
@@ -103,7 +107,9 @@ public class TestDriftNettyClientConfig
                 .setConnectionPoolEnabled(true)
                 .setConnectionPoolMaxConnectionsPerDestination(123)
                 .setConnectionPoolMaxSize(321)
-                .setConnectionPoolIdleTimeout(new Duration(12, MINUTES));
+                .setConnectionPoolIdleTimeout(new Duration(12, MINUTES))
+                .setTcpNoDelayEnabled(true)
+                .setReuseAddressEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestDriftNettyMethodInvoker.java
+++ b/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestDriftNettyMethodInvoker.java
@@ -337,7 +337,9 @@ public class TestDriftNettyMethodInvoker
                         new Duration(11, MILLISECONDS),
                         new Duration(13, MILLISECONDS),
                         Optional.empty(),
-                        Optional.empty()),
+                        Optional.empty(),
+                        false,
+                        false),
                 new HangingConnectionManager(),
                 executor,
                 new Duration(17, MILLISECONDS));


### PR DESCRIPTION
The default connection pool properties, such as
`thrift.client.connection-pool.enabled` can now be overriden per
Drift client by adding the Drift client prefix, e.g.:
`<prefix>.thrift.client.connection-pool.enabled`