### PR TITLE
Share delayService across clients

### DIFF
--- a/drift-client/src/main/java/com/facebook/drift/client/DriftClientFactoryConfig.java
+++ b/drift-client/src/main/java/com/facebook/drift/client/DriftClientFactoryConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.drift.client;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+
+import javax.validation.constraints.Min;
+
+public class DriftClientFactoryConfig
+{
+    private int numRetryServiceThreadCount = 2 * Runtime.getRuntime().availableProcessors();
+
+    @Min(1)
+    public int getNumRetryServiceThreadCount()
+    {
+        return numRetryServiceThreadCount;
+    }
+
+    @Config("thrift.client.num-retry-service-thread-count")
+    @ConfigDescription("Number of threads of the executor which handles part of thrift request retries")
+    public DriftClientFactoryConfig setNumRetryServiceThreadCount(int numRetryServiceThreadCount)
+    {
+        this.numRetryServiceThreadCount = numRetryServiceThreadCount;
+        return this;
+    }
+}

--- a/drift-client/src/main/java/com/facebook/drift/client/DriftClientFactoryManager.java
+++ b/drift-client/src/main/java/com/facebook/drift/client/DriftClientFactoryManager.java
@@ -21,6 +21,8 @@ import com.facebook.drift.client.stats.NullMethodInvocationStatsFactory;
 import com.facebook.drift.codec.ThriftCodecManager;
 import com.facebook.drift.transport.client.MethodInvokerFactory;
 
+import java.util.concurrent.Executor;
+
 import static java.util.Objects.requireNonNull;
 
 public class DriftClientFactoryManager<I>
@@ -28,19 +30,22 @@ public class DriftClientFactoryManager<I>
     private final ThriftCodecManager codecManager;
     private final MethodInvokerFactory<I> methodInvokerFactory;
     private final MethodInvocationStatsFactory methodInvocationStatsFactory;
+    private final Executor retryService;
 
-    public DriftClientFactoryManager(ThriftCodecManager codecManager, MethodInvokerFactory<I> methodInvokerFactory)
+    public DriftClientFactoryManager(ThriftCodecManager codecManager, MethodInvokerFactory<I> methodInvokerFactory, Executor retryService)
     {
-        this(codecManager, methodInvokerFactory, new NullMethodInvocationStatsFactory());
+        this(codecManager, methodInvokerFactory, new NullMethodInvocationStatsFactory(), retryService);
     }
 
     public DriftClientFactoryManager(ThriftCodecManager codecManager,
             MethodInvokerFactory<I> methodInvokerFactory,
-            MethodInvocationStatsFactory methodInvocationStatsFactory)
+            MethodInvocationStatsFactory methodInvocationStatsFactory,
+            Executor retryService)
     {
         this.codecManager = requireNonNull(codecManager, "codecManager is null");
         this.methodInvokerFactory = requireNonNull(methodInvokerFactory, "methodInvokerFactory is null");
         this.methodInvocationStatsFactory = methodInvocationStatsFactory;
+        this.retryService = requireNonNull(retryService, "retryService is null");
     }
 
     public DriftClientFactory createDriftClientFactory(I clientIdentity, AddressSelector<?> addressSelector, ExceptionClassifier exceptionClassifier)
@@ -50,6 +55,7 @@ public class DriftClientFactoryManager<I>
                 () -> methodInvokerFactory.createMethodInvoker(clientIdentity),
                 addressSelector,
                 exceptionClassifier,
-                methodInvocationStatsFactory);
+                methodInvocationStatsFactory,
+                retryService);
     }
 }

--- a/drift-client/src/main/java/com/facebook/drift/client/DriftMethodHandler.java
+++ b/drift-client/src/main/java/com/facebook/drift/client/DriftMethodHandler.java
@@ -15,7 +15,6 @@
  */
 package com.facebook.drift.client;
 
-import com.facebook.airlift.concurrent.BoundedExecutor;
 import com.facebook.drift.client.address.AddressSelector;
 import com.facebook.drift.client.stats.MethodInvocationStat;
 import com.facebook.drift.codec.metadata.ThriftHeaderParameter;
@@ -32,6 +31,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Executor;
 
 import static com.facebook.drift.client.DriftMethodInvocation.createDriftMethodInvocation;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -47,7 +47,7 @@ class DriftMethodHandler
     private final AddressSelector<? extends Address> addressSelector;
     private final RetryPolicy retryPolicy;
     private final MethodInvocationStat stat;
-    private final BoundedExecutor retryService;
+    private final Executor retryService;
 
     public DriftMethodHandler(
             MethodMetadata metadata,
@@ -57,7 +57,7 @@ class DriftMethodHandler
             AddressSelector<? extends Address> addressSelector,
             RetryPolicy retryPolicy,
             MethodInvocationStat stat,
-            BoundedExecutor retryService)
+            Executor retryService)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.headerParameters = requireNonNull(headersParameters, "headersParameters is null").stream()

--- a/drift-client/src/main/java/com/facebook/drift/client/DriftMethodInvocation.java
+++ b/drift-client/src/main/java/com/facebook/drift/client/DriftMethodInvocation.java
@@ -15,7 +15,6 @@
  */
 package com.facebook.drift.client;
 
-import com.facebook.airlift.concurrent.BoundedExecutor;
 import com.facebook.airlift.log.Logger;
 import com.facebook.drift.TException;
 import com.facebook.drift.client.address.AddressSelector;
@@ -44,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Executor;
 
 import static com.facebook.drift.client.ExceptionClassification.HostStatus.DOWN;
 import static com.facebook.drift.client.ExceptionClassification.HostStatus.NORMAL;
@@ -69,7 +69,7 @@ class DriftMethodInvocation<A extends Address>
     private final Optional<String> addressSelectionContext;
     private final MethodInvocationStat stat;
     private final Ticker ticker;
-    private final BoundedExecutor retryService;
+    private final Executor retryService;
     private final long startTime;
 
     @GuardedBy("this")
@@ -98,7 +98,7 @@ class DriftMethodInvocation<A extends Address>
             Optional<String> addressSelectionContext,
             MethodInvocationStat stat,
             Ticker ticker,
-            BoundedExecutor retryService)
+            Executor retryService)
     {
         DriftMethodInvocation<A> invocation = new DriftMethodInvocation<>(
                 invoker,
@@ -126,7 +126,7 @@ class DriftMethodInvocation<A extends Address>
             Optional<String> addressSelectionContext,
             MethodInvocationStat stat,
             Ticker ticker,
-            BoundedExecutor retryService)
+            Executor retryService)
     {
         this.invoker = requireNonNull(invoker, "methodHandler is null");
         this.metadata = requireNonNull(metadata, "metadata is null");

--- a/drift-client/src/main/java/com/facebook/drift/client/ForRetryService.java
+++ b/drift-client/src/main/java/com/facebook/drift/client/ForRetryService.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.drift.client;
+
+public @interface ForRetryService
+{
+}

--- a/drift-client/src/test/java/com/facebook/drift/client/TestDriftClient.java
+++ b/drift-client/src/test/java/com/facebook/drift/client/TestDriftClient.java
@@ -61,6 +61,7 @@ import static com.facebook.drift.client.guice.DriftClientBinder.driftClientBinde
 import static com.facebook.drift.client.guice.MethodInvocationFilterBinder.staticFilterBinder;
 import static com.google.common.base.Throwables.getCausalChain;
 import static com.google.common.base.Throwables.getRootCause;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static java.lang.annotation.ElementType.FIELD;
@@ -92,7 +93,7 @@ public class TestDriftClient
         TestingMethodInvocationStatsFactory statsFactory = new TestingMethodInvocationStatsFactory();
         List<TestingExceptionClassifier> classifiers = ImmutableList.of(new TestingExceptionClassifier(), new TestingExceptionClassifier(), new TestingExceptionClassifier());
 
-        DriftClientFactoryManager<String> clientFactoryManager = new DriftClientFactoryManager<>(codecManager, methodInvokerFactory, statsFactory);
+        DriftClientFactoryManager<String> clientFactoryManager = new DriftClientFactoryManager<>(codecManager, methodInvokerFactory, statsFactory, directExecutor());
         DriftClientFactory driftClientFactory = clientFactoryManager.createDriftClientFactory("clientIdentity", new MockAddressSelector(), mergeExceptionClassifiers(classifiers));
 
         DriftClient<Client> driftClient = driftClientFactory.createDriftClient(Client.class, Optional.empty(), ImmutableList.of(), new DriftClientConfig());
@@ -114,7 +115,7 @@ public class TestDriftClient
         TestingMethodInvocationStatsFactory statsFactory = new TestingMethodInvocationStatsFactory();
         List<TestingExceptionClassifier> classifiers = ImmutableList.of(new TestingExceptionClassifier(), new TestingExceptionClassifier(), new TestingExceptionClassifier());
 
-        DriftClientFactoryManager<String> clientFactoryManager = new DriftClientFactoryManager<>(codecManager, invokerFactory, statsFactory);
+        DriftClientFactoryManager<String> clientFactoryManager = new DriftClientFactoryManager<>(codecManager, invokerFactory, statsFactory, directExecutor());
         DriftClientFactory driftClientFactory = clientFactoryManager.createDriftClientFactory("clientIdentity", new MockAddressSelector(), mergeExceptionClassifiers(classifiers));
 
         DriftClient<Client> driftClient = driftClientFactory.createDriftClient(

--- a/drift-client/src/test/java/com/facebook/drift/client/TestDriftClientFactoryConfig.java
+++ b/drift-client/src/test/java/com/facebook/drift/client/TestDriftClientFactoryConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.drift.client;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestDriftClientFactoryConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(DriftClientFactoryConfig.class)
+                .setNumRetryServiceThreadCount(Runtime.getRuntime().availableProcessors() * 2));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("thrift.client.num-retry-service-thread-count", "99")
+                .build();
+
+        DriftClientFactoryConfig expected = new DriftClientFactoryConfig()
+                .setNumRetryServiceThreadCount(99);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/drift-integration-tests/src/test/java/com/facebook/drift/integration/ApacheThriftTesterUtil.java
+++ b/drift-integration-tests/src/test/java/com/facebook/drift/integration/ApacheThriftTesterUtil.java
@@ -45,6 +45,7 @@ import static com.facebook.drift.integration.ClientTestUtils.logDriftClientBinde
 import static com.facebook.drift.transport.apache.client.ApacheThriftMethodInvokerFactory.createStaticApacheThriftMethodInvokerFactory;
 import static com.facebook.drift.transport.netty.codec.Protocol.FB_COMPACT;
 import static com.facebook.drift.transport.netty.codec.Transport.HEADER;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static org.testng.Assert.assertEquals;
 
 final class ApacheThriftTesterUtil
@@ -81,7 +82,7 @@ final class ApacheThriftTesterUtil
                 .setSslEnabled(secure);
         ApacheThriftConnectionFactoryConfig factoryConfig = new ApacheThriftConnectionFactoryConfig();
         try (ApacheThriftMethodInvokerFactory<String> methodInvokerFactory = new ApacheThriftMethodInvokerFactory<>(factoryConfig, clientIdentity -> config)) {
-            DriftClientFactoryManager<String> clientFactoryManager = new DriftClientFactoryManager<>(CODEC_MANAGER, methodInvokerFactory);
+            DriftClientFactoryManager<String> clientFactoryManager = new DriftClientFactoryManager<>(CODEC_MANAGER, methodInvokerFactory, directExecutor());
             DriftClientFactory proxyFactory = clientFactoryManager.createDriftClientFactory("clientIdentity", addressSelector, NORMAL_RESULT);
 
             DriftScribe scribe = proxyFactory.createDriftClient(DriftScribe.class, Optional.empty(), filters, new DriftClientConfig()).get();
@@ -115,7 +116,7 @@ final class ApacheThriftTesterUtil
                 .setSslEnabled(secure);
 
         try (ApacheThriftMethodInvokerFactory<?> methodInvokerFactory = createStaticApacheThriftMethodInvokerFactory(config)) {
-            DriftClientFactory proxyFactory = new DriftClientFactory(CODEC_MANAGER, methodInvokerFactory, addressSelector);
+            DriftClientFactory proxyFactory = new DriftClientFactory(CODEC_MANAGER, methodInvokerFactory, addressSelector, directExecutor());
 
             DriftScribe scribe = proxyFactory.createDriftClient(DriftScribe.class, Optional.empty(), filters, new DriftClientConfig()).get();
 
@@ -148,7 +149,7 @@ final class ApacheThriftTesterUtil
                 .setSslEnabled(secure);
         ApacheThriftConnectionFactoryConfig factoryConfig = new ApacheThriftConnectionFactoryConfig();
         try (ApacheThriftMethodInvokerFactory<String> methodInvokerFactory = new ApacheThriftMethodInvokerFactory<>(factoryConfig, clientIdentity -> config)) {
-            DriftClientFactoryManager<String> proxyFactoryManager = new DriftClientFactoryManager<>(CODEC_MANAGER, methodInvokerFactory);
+            DriftClientFactoryManager<String> proxyFactoryManager = new DriftClientFactoryManager<>(CODEC_MANAGER, methodInvokerFactory, directExecutor());
             DriftClientFactory proxyFactory = proxyFactoryManager.createDriftClientFactory("myFactory", addressSelector, NORMAL_RESULT);
 
             DriftAsyncScribe scribe = proxyFactory.createDriftClient(DriftAsyncScribe.class, Optional.empty(), filters, new DriftClientConfig()).get();

--- a/drift-integration-tests/src/test/java/com/facebook/drift/integration/DriftNettyTesterUtil.java
+++ b/drift-integration-tests/src/test/java/com/facebook/drift/integration/DriftNettyTesterUtil.java
@@ -46,6 +46,7 @@ import static com.facebook.drift.integration.ClientTestUtils.logDriftClientBinde
 import static com.facebook.drift.transport.netty.client.DriftNettyMethodInvokerFactory.createStaticDriftNettyMethodInvokerFactory;
 import static com.facebook.drift.transport.netty.codec.Protocol.COMPACT;
 import static com.facebook.drift.transport.netty.codec.Transport.HEADER;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static org.testng.Assert.assertEquals;
 
 final class DriftNettyTesterUtil
@@ -86,7 +87,7 @@ final class DriftNettyTesterUtil
                         new DriftNettyConnectionFactoryConfig(),
                         clientIdentity -> config,
                         testingAllocator)) {
-            DriftClientFactoryManager<String> clientFactoryManager = new DriftClientFactoryManager<>(CODEC_MANAGER, methodInvokerFactory);
+            DriftClientFactoryManager<String> clientFactoryManager = new DriftClientFactoryManager<>(CODEC_MANAGER, methodInvokerFactory, directExecutor());
             DriftClientFactory proxyFactory = clientFactoryManager.createDriftClientFactory("clientIdentity", addressSelector, NORMAL_RESULT);
 
             DriftScribe scribe = proxyFactory.createDriftClient(DriftScribe.class, Optional.empty(), filters, new DriftClientConfig()).get();
@@ -121,7 +122,7 @@ final class DriftNettyTesterUtil
 
         try (TestingPooledByteBufAllocator testingAllocator = new TestingPooledByteBufAllocator();
                 DriftNettyMethodInvokerFactory<?> methodInvokerFactory = createStaticDriftNettyMethodInvokerFactory(config, testingAllocator)) {
-            DriftClientFactory proxyFactory = new DriftClientFactory(CODEC_MANAGER, methodInvokerFactory, addressSelector);
+            DriftClientFactory proxyFactory = new DriftClientFactory(CODEC_MANAGER, methodInvokerFactory, addressSelector, directExecutor());
 
             DriftScribe scribe = proxyFactory.createDriftClient(DriftScribe.class, Optional.empty(), filters, new DriftClientConfig()).get();
 
@@ -158,7 +159,7 @@ final class DriftNettyTesterUtil
                         new DriftNettyConnectionFactoryConfig(),
                         clientIdentity -> config,
                         testingAllocator)) {
-            DriftClientFactoryManager<String> proxyFactoryManager = new DriftClientFactoryManager<>(CODEC_MANAGER, methodInvokerFactory);
+            DriftClientFactoryManager<String> proxyFactoryManager = new DriftClientFactoryManager<>(CODEC_MANAGER, methodInvokerFactory, directExecutor());
             DriftClientFactory proxyFactory = proxyFactoryManager.createDriftClientFactory("myFactory", addressSelector, NORMAL_RESULT);
 
             DriftAsyncScribe scribe = proxyFactory.createDriftClient(DriftAsyncScribe.class, Optional.empty(), filters, new DriftClientConfig()).get();


### PR DESCRIPTION
delayService normally feeds into the eventLoop which has a max of
2 * num core threads shared across all clients created in the drift
session. We should not need more than the number of threads that
are being used by the eventLoop