### PR TITLE
Differentiate different types of Drift failures

### DIFF
--- a/drift-client/src/main/java/com/facebook/drift/client/exceptions/DriftMaxRetryAttemptsExceededException.java
+++ b/drift-client/src/main/java/com/facebook/drift/client/exceptions/DriftMaxRetryAttemptsExceededException.java
@@ -1,0 +1,23 @@
+package com.facebook.drift.client.exceptions;
+
+import com.facebook.drift.transport.client.Address;
+import io.airlift.units.Duration;
+
+import java.util.Set;
+
+import static java.lang.String.format;
+
+public class DriftMaxRetryAttemptsExceededException
+    extends DriftRetriesFailedException
+{
+    public DriftMaxRetryAttemptsExceededException(
+            int maxRetries,
+            int invocationAttempts,
+            Duration retryTime,
+            int failedConnections,
+            int overloadedRejects,
+            Set<? extends Address> attemptedAddresses)
+    {
+        super(format("Max retry attempts (%s) exceeded", maxRetries), invocationAttempts, retryTime, failedConnections, overloadedRejects, attemptedAddresses);
+    }
+}

--- a/drift-client/src/main/java/com/facebook/drift/client/exceptions/DriftNoHostsAvailableException.java
+++ b/drift-client/src/main/java/com/facebook/drift/client/exceptions/DriftNoHostsAvailableException.java
@@ -1,0 +1,15 @@
+package com.facebook.drift.client.exceptions;
+
+import com.facebook.drift.transport.client.Address;
+import io.airlift.units.Duration;
+
+import java.util.Set;
+
+public class DriftNoHostsAvailableException
+    extends DriftRetriesFailedException
+{
+    public DriftNoHostsAvailableException(int invocationAttempts, Duration retryTime, int failedConnections, int overloadedRejects, Set<? extends Address> attemptedAddresses)
+    {
+        super("No hosts available", invocationAttempts, retryTime, failedConnections, overloadedRejects, attemptedAddresses);
+    }
+}

--- a/drift-client/src/main/java/com/facebook/drift/client/exceptions/DriftNonRetryableException.java
+++ b/drift-client/src/main/java/com/facebook/drift/client/exceptions/DriftNonRetryableException.java
@@ -1,0 +1,15 @@
+package com.facebook.drift.client.exceptions;
+
+import com.facebook.drift.transport.client.Address;
+import io.airlift.units.Duration;
+
+import java.util.Set;
+
+public class DriftNonRetryableException
+    extends DriftRetriesFailedException
+{
+    public DriftNonRetryableException(int invocationAttempts, Duration retryTime, int failedConnections, int overloadedRejects, Set<? extends Address> attemptedAddresses)
+    {
+        super("Non-retryable exception", invocationAttempts, retryTime, failedConnections, overloadedRejects, attemptedAddresses);
+    }
+}

--- a/drift-client/src/main/java/com/facebook/drift/client/exceptions/DriftRetriesFailedException.java
+++ b/drift-client/src/main/java/com/facebook/drift/client/exceptions/DriftRetriesFailedException.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.drift.client;
+package com.facebook.drift.client.exceptions;
 
 import com.facebook.drift.transport.client.Address;
 import com.google.common.collect.ImmutableSet;
@@ -24,7 +24,7 @@ import java.util.Set;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-public class RetriesFailedException
+public class DriftRetriesFailedException
         extends Exception
 {
     private final int invocationAttempts;
@@ -33,7 +33,7 @@ public class RetriesFailedException
     private final int overloadedRejects;
     private final Set<? extends Address> attemptedAddresses;
 
-    public RetriesFailedException(
+    DriftRetriesFailedException(
             String reason,
             int invocationAttempts,
             Duration retryTime,

--- a/drift-client/src/main/java/com/facebook/drift/client/exceptions/DriftRetryTimeExceededException.java
+++ b/drift-client/src/main/java/com/facebook/drift/client/exceptions/DriftRetryTimeExceededException.java
@@ -1,0 +1,23 @@
+package com.facebook.drift.client.exceptions;
+
+import com.facebook.drift.transport.client.Address;
+import io.airlift.units.Duration;
+
+import java.util.Set;
+
+import static java.lang.String.format;
+
+public class DriftRetryTimeExceededException
+    extends DriftRetriesFailedException
+{
+    public DriftRetryTimeExceededException(
+            Duration maxRetryTime,
+            int invocationAttempts,
+            Duration retryTime,
+            int failedConnections,
+            int overloadedRejects,
+            Set<? extends Address> attemptedAddresses)
+    {
+        super(format("Max retry time (%s) exceeded", maxRetryTime), invocationAttempts, retryTime, failedConnections, overloadedRejects, attemptedAddresses);
+    }
+}

--- a/drift-integration-tests/src/test/java/com/facebook/drift/integration/guice/TestGuiceIntegration.java
+++ b/drift-integration-tests/src/test/java/com/facebook/drift/integration/guice/TestGuiceIntegration.java
@@ -20,7 +20,7 @@ import com.facebook.airlift.bootstrap.LifeCycleManager;
 import com.facebook.drift.TApplicationException;
 import com.facebook.drift.TException;
 import com.facebook.drift.client.ExceptionClassification;
-import com.facebook.drift.client.RetriesFailedException;
+import com.facebook.drift.client.exceptions.DriftRetriesFailedException;
 import com.facebook.drift.integration.guice.EchoService.EmptyOptionalException;
 import com.facebook.drift.integration.guice.EchoService.NullValueException;
 import com.facebook.drift.integration.scribe.drift.DriftLogEntry;
@@ -250,7 +250,7 @@ public class TestGuiceIntegration
             assertFalse(e.isRetryable());
             assertEquals(e.getSuppressed().length, 1);
             Throwable t = e.getSuppressed()[0];
-            assertThat(t).isInstanceOf(RetriesFailedException.class)
+            assertThat(t).isInstanceOf(DriftRetriesFailedException.class)
                     .hasMessageContaining("Non-retryable exception")
                     .hasMessageContaining("invocationAttempts: 1,");
         }
@@ -264,7 +264,7 @@ public class TestGuiceIntegration
             assertTrue(e.isRetryable());
             assertEquals(e.getSuppressed().length, 1);
             Throwable t = e.getSuppressed()[0];
-            assertThat(t).isInstanceOf(RetriesFailedException.class)
+            assertThat(t).isInstanceOf(DriftRetriesFailedException.class)
                     .hasMessageContaining("Max retry attempts (5) exceeded")
                     .hasMessageContaining("invocationAttempts: 6,");
         }
@@ -281,7 +281,7 @@ public class TestGuiceIntegration
                     .hasMessageMatching("Frame size .+ exceeded max size .+");
             assertEquals(e.getSuppressed().length, 1);
             Throwable t = e.getSuppressed()[0];
-            assertThat(t).isInstanceOf(RetriesFailedException.class)
+            assertThat(t).isInstanceOf(DriftRetriesFailedException.class)
                     .hasMessageContaining("Non-retryable exception")
                     .hasMessageContaining("invocationAttempts: 1,");
         }


### PR DESCRIPTION
It's sometimes useful to log the reason for a failure.  By separating out the specific
failure reasons into different exceptions, clients can now inspect the underlying failure
reason.  This may be useful for logging, or for publication of custom metrics.