### PR TITLE
Add netty-transport-native-epoll dependency to drift-netty-transport

### DIFF
--- a/drift-transport-netty/pom.xml
+++ b/drift-transport-netty/pom.xml
@@ -108,6 +108,13 @@
 
         <dependency>
             <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <classifier>linux-x86_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
         </dependency>
 


### PR DESCRIPTION
We already add `netty-transport-classes-epoll`, but that doesn't do much without the native libs. So add them here.