### PR TITLE
Use Header transport and provide "thrift" ALPN

### DIFF
--- a/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/DriftNettyClientConfig.java
+++ b/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/DriftNettyClientConfig.java
@@ -33,7 +33,7 @@ import java.io.File;
 import java.util.List;
 
 import static com.facebook.drift.transport.netty.codec.Protocol.BINARY;
-import static com.facebook.drift.transport.netty.codec.Transport.FRAMED;
+import static com.facebook.drift.transport.netty.codec.Transport.HEADER;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.DAYS;
@@ -42,7 +42,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class DriftNettyClientConfig
 {
-    private Transport transport = FRAMED;
+    private Transport transport = HEADER;
     private Protocol protocol = BINARY;
     private DataSize maxFrameSize = new DataSize(16, MEGABYTE);
 

--- a/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestDriftNettyClientConfig.java
+++ b/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestDriftNettyClientConfig.java
@@ -44,7 +44,7 @@ public class TestDriftNettyClientConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(DriftNettyClientConfig.class)
-                .setTransport(FRAMED)
+                .setTransport(HEADER)
                 .setProtocol(BINARY)
                 .setConnectTimeout(new Duration(500, MILLISECONDS))
                 .setRequestTimeout(new Duration(10, SECONDS))
@@ -69,7 +69,7 @@ public class TestDriftNettyClientConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("thrift.client.transport", "HEADER")
+                .put("thrift.client.transport", "FRAMED")
                 .put("thrift.client.protocol", "COMPACT")
                 .put("thrift.client.connect-timeout", "99ms")
                 .put("thrift.client.request-timeout", "33m")
@@ -91,7 +91,8 @@ public class TestDriftNettyClientConfig
                 .build();
 
         DriftNettyClientConfig expected = new DriftNettyClientConfig()
-                .setTransport(HEADER)
+                // testing a Transport that is not the default (HEADER)
+                .setTransport(FRAMED)
                 .setProtocol(COMPACT)
                 .setConnectTimeout(new Duration(99, MILLISECONDS))
                 .setRequestTimeout(new Duration(33, MINUTES))

--- a/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestDriftNettyMethodInvoker.java
+++ b/drift-transport-netty/src/test/java/com/facebook/drift/transport/netty/client/TestDriftNettyMethodInvoker.java
@@ -372,6 +372,8 @@ public class TestDriftNettyMethodInvoker
     private static int logNiftyInvocationHandlerOptional(HostAndPort address, List<DriftLogEntry> entries)
     {
         DriftNettyClientConfig config = new DriftNettyClientConfig();
+        config.setTransport(FRAMED);
+
         try (TestingPooledByteBufAllocator testingAllocator = new TestingPooledByteBufAllocator();
                 DriftNettyMethodInvokerFactory<Void> methodInvokerFactory = new DriftNettyMethodInvokerFactory<>(
                         new DriftNettyConnectionFactoryConfig(),


### PR DESCRIPTION
Framed, Unframed, and Header are all legacy protocols and considered deprecated. Still, Header is newer and slightly better maintained on the C++ side. Set it as the default for all clients.

Provide an ALPN. This is particularly useful for clients connecting to a C++ server. The server won't have to peek at the bytes to decide that this is a Header (or Framed or Unframed) connection. The ALPN value of "thrift" indicates all that.