### PR TITLE
Upgrade maven-gpg-plugin to 3.2.4

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with: 
+      with:
         show-progress: false
         # needed for the git-commit-id-plugin to work
         fetch-depth: 0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,6 @@ pipeline {
                     gpg --batch --import ${GPG_SECRET}
                     echo ${GPG_TRUST} | gpg --import-ownertrust -
                     gpg --list-secret-keys
-                    echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
                     printenv | sort
 
                     git checkout ${REPO_RELEASE_TAG}

--- a/pom.xml
+++ b/pom.xml
@@ -397,11 +397,18 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.4</version>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>deploy-to-ossrh</id>
             <build>


### PR DESCRIPTION
This fixes the signing error in the Jenkins release pipeline. The current version is 1.4, inherited from airbase.

`gpg: signing failed: Inappropriate ioctl for device`