### PR TITLE
Adding Float <--> float coercions

### DIFF
--- a/drift-codec/src/main/java/com/facebook/drift/codec/internal/coercion/DefaultJavaCoercions.java
+++ b/drift-codec/src/main/java/com/facebook/drift/codec/internal/coercion/DefaultJavaCoercions.java
@@ -87,6 +87,18 @@ public final class DefaultJavaCoercions
     }
 
     @FromThrift
+    public static Float floatToBoxedFloat(float value)
+    {
+        return value;
+    }
+
+    @ToThrift
+    public static float boxedFloatToFloat(Float value)
+    {
+        return value;
+    }
+
+    @FromThrift
     public static float doubleToPrimitiveFloat(double value)
     {
         return (float) value;


### PR DESCRIPTION
Summary
After testing with changes from https://github.com/prestodb/drift/pull/57, we realized we needed to include coercion logic from Float to float (and the other way around as well).

Test Plan: Existent unittests. Also, built local changes and tested previously failing deserialization test, which now passes: P1745467072.